### PR TITLE
Switched to levelup for node v0.10 compatibility

### DIFF
--- a/lib/leveldb.js
+++ b/lib/leveldb.js
@@ -17,7 +17,8 @@
 // limitations under the License.
 
 var databank = require('databank'),
-    leveldb = require('leveldb'),
+    levelup = require('levelup'),
+    leveldown = require('leveldown'),
     crypto = require('crypto'),
     fs = require('fs'),
     path = require('path'),
@@ -45,7 +46,7 @@ LevelDBDatabank.toKey = function(type, id) {
 LevelDBDatabank.prototype.connect = function(params, callback) {
     var bank = this,
         realConnect = function() {
-            leveldb.open(bank.file, { create_if_missing: true }, function(err, handle) {
+            levelup(bank.file, { valueEncoding: 'json' }, function(err, handle) {
                 if (err) {
                     callback(err);
                 } else if (!handle) {
@@ -86,8 +87,8 @@ LevelDBDatabank.prototype.makeTempDir = function(callback) {
                 } else {
                     dirname = path.join(tmp, rs);
                     fs.stat(dirname, function(err, stats) {
-		        if (err && err.code == 'ENOENT') {
-                            bank.dir = dirname;
+                        if (err && err.code == 'ENOENT') {
+                            bank.file = dirname;
                             callback(null);
                         } else if (err) {
                             callback(err);
@@ -128,13 +129,19 @@ LevelDBDatabank.prototype.disconnect = function(callback) {
         return;
     }
 
-    bank.handle = null;
+    bank.handle.close(function(err) {
+        if(err) {
+            callback(err);
+        } else {
+            bank.handle = null;
 
-    if (bank.mktmp) {
-        leveldb.destroy(bank.file, {}, callback);
-    } else {
-        callback(null);
-    }
+            if (bank.mktmp) {
+                leveldown.destroy(bank.file, callback);
+            } else {
+                callback(null);
+            }
+        }
+    });
 };
 
 LevelDBDatabank.prototype.create = function(type, id, value, callback) {
@@ -145,20 +152,22 @@ LevelDBDatabank.prototype.create = function(type, id, value, callback) {
         callback(new NotConnectedError(), null);
         return;
     }
-    
+
     bank.handle.get(key, function(err, results) {
         if (err) {
-            callback(err, null);
-        } else if (results) {
-            callback(new AlreadyExistsError(type, id), null);
+            if (err.name === 'NotFoundError') {
+                bank.handle.put(key, value, function(err) {
+                    if (err) {
+                        callback(err, null);
+                    } else {
+                        callback(null, value);
+                    }
+                });
+            } else {
+                callback(err, null);
+            }
         } else {
-            bank.handle.put(key, JSON.stringify(value), function(err) {
-                if (err) {
-                    callback(err, null);
-                } else {
-                    callback(null, value);
-                }
-            });
+            callback(new AlreadyExistsError(type, id), null);
         }
     });
 };
@@ -174,11 +183,13 @@ LevelDBDatabank.prototype.read = function(type, id, callback) {
 
     bank.handle.get(key, function(err, value) {
         if (err) {
-            callback(err, null);
-        } else if (!value) {
-            callback(new NoSuchThingError(type, id), null);
+            if (err.name === 'NotFoundError') {
+                callback(new NoSuchThingError(type, id), null);
+            } else {
+                callback(err, null);
+            }
         } else {
-            callback(null, JSON.parse(value));
+            callback(null, value);
         }
     });
 };
@@ -194,11 +205,13 @@ LevelDBDatabank.prototype.update = function(type, id, value, callback) {
 
     bank.handle.get(key, function(err, results) {
         if (err) {
-            callback(err, null);
-        } else if (!results) {
-            callback(new NoSuchThingError(type, id), null);
+            if (err.name === 'NotFoundError') {
+                callback(new NoSuchThingError(type, id), null);
+            } else {
+                callback(err, null);
+            }
         } else {
-            bank.handle.put(key, JSON.stringify(value), function(err) {
+            bank.handle.put(key, value, function(err) {
                 if (err) {
                     callback(err, null);
                 } else {
@@ -220,9 +233,11 @@ LevelDBDatabank.prototype.del = function(type, id, callback) {
 
     bank.handle.get(key, function(err, results) {
         if (err) {
-            callback(err, null);
-        } else if (!results) {
-            callback(new NoSuchThingError(type, id), null);
+            if (err.name === 'NotFoundError') {
+                callback(new NoSuchThingError(type, id), null);
+            } else {
+                callback(err, null);
+            }
         } else {
             bank.handle.del(key, {}, callback);
         }
@@ -232,42 +247,34 @@ LevelDBDatabank.prototype.del = function(type, id, callback) {
 LevelDBDatabank.prototype.search = function(type, criteria, onResult, onCompletion) {
     var bank = this;
 
+    bank.scan(type, function(value) {
+        if (bank.matchesCriteria(value, criteria)) {
+            onResult(value);
+        }
+    }, onCompletion);
+};
+
+LevelDBDatabank.prototype.scan = function(type, onResult, onCompletion) {
+    var bank = this;
+
     if (!bank.handle) {
         onCompletion(new NotConnectedError());
         return;
     }
 
-    bank.handle.iterator(null, function(err, it) {
-        var seenErr = null,
-            onItem = function(err, key, value) {
-                var obj;
-                if (seenErr) {
-                    return;
-                }
-                if (err) {
-                    seenErr = err;
-                    return;
-                }
-                if (key.substr(0, type.length + 1) === type + ":") {
-                    obj = JSON.parse(value);
-                    if (bank.matchesCriteria(obj, criteria)) {
-                        onResult(obj);
-                    }
-                }
-            },
-            onFinish = function() {
-                if (seenErr) {
-                    onCompletion(seenErr);
-                } else {
-                    onCompletion(null);
-                }
-            };
+    var dataStream = bank.handle.createReadStream();
 
-        if (err) {
-            onCompletion(err);
-            return;
+    dataStream.on('data', function(data) {
+        if (data.key.substr(0, type.length + 1) === type + ":") {
+            onResult(data.value);
         }
-        it.forRange(null, null, onItem, onFinish);
+    });
+    dataStream.on('error', function(err) {
+        onCompletion(err);
+        dataStream.destroy();
+    });
+    dataStream.on('end', function() {
+        onCompletion(null);
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,37 +1,46 @@
 {
-    "name": "databank-leveldb",
-    "version": "0.1.0",
-    "engines": { "node": ">=0.6.x" },
-    "author": "Evan Prodromou <evan@status.net>",
-    "scripts": {"test": "vows test/*-test.js"},
-    "main": "./lib/leveldb.js",
-    "directories": {"lib": "./lib/"},
-    "description": "LevelDB driver for Databank",
-    "dependencies": {
-        "leveldb": "0.7.x", 
-        "databank": "0.14.x"
-    },
-    "devDependencies": {
-        "vows": "0.6.x" 
-    },
-    "licenses": [
-        {
-           "type": "Apache-2.0",
-           "url": "http://www.apache.org/licenses/LICENSE-2.0"
-        }
-    ],
-     "keywords": [
-        "databank",
-        "leveldb",
-        "database", 
-        "json", 
-        "storage", 
-        "nosql" 
-     ],
-    "homepage": "http://github.com/evanp/databank-leveldb",
-    "bugs": {
-       "web": "http://github.com/evanp/databank-leveldb/issues"
-    },
-    "repository": { "type":  "git",
-                    "url":   "http://github.com/evanp/databank-leveldb.git" }
+  "name": "databank-leveldb",
+  "version": "0.1.0",
+  "engines": {
+    "node": ">=0.6.x"
+  },
+  "author": "Evan Prodromou <evan@status.net>",
+  "scripts": {
+    "test": "vows test/*-test.js"
+  },
+  "main": "./lib/leveldb.js",
+  "directories": {
+    "lib": "./lib/"
+  },
+  "description": "LevelDB driver for Databank",
+  "dependencies": {
+    "databank": "~0.18.2",
+    "levelup": "~0.9.0",
+    "leveldown": "~0.5.0"
+  },
+  "devDependencies": {
+    "vows": "0.7.x"
+  },
+  "licenses": [
+    {
+      "type": "Apache-2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    }
+  ],
+  "keywords": [
+    "databank",
+    "leveldb",
+    "database",
+    "json",
+    "storage",
+    "nosql"
+  ],
+  "homepage": "http://github.com/evanp/databank-leveldb",
+  "bugs": {
+    "web": "http://github.com/evanp/databank-leveldb/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/evanp/databank-leveldb.git"
+  }
 }

--- a/test/leveldb-driver-test.js
+++ b/test/leveldb-driver-test.js
@@ -24,6 +24,6 @@ var assert = require('assert'),
 
 Databank.register('leveldb', LevelDBDatabank);
 
-var suite = databank.DriverTest('leveldb', {file: '/tmp/leveldb-driver-test'});
+var suite = databank.DriverTest('leveldb', {mktmp: true});
 
 suite['export'](module);


### PR DESCRIPTION
Uses levelup, which seems to be better mantained compared to leveldb. Also added the scan() method in order to pass all tests with the current databank version.
